### PR TITLE
Fixed Makerna Patron Exploit

### DIFF
--- a/data/area/makarna_training.js
+++ b/data/area/makarna_training.js
@@ -10,6 +10,11 @@ var area = {
                 "subtitle": "A mysterious door here leads to the patrons-only area.",
                 "type": "random", //or random
                 "requirements": [
+                    {
+                        "parameter": "contributor",
+                        "value": 0,
+                        "comparison": "greater" //default greater
+                    }
                 ],
                 "icon": "navigateicon",
                 "results": {


### PR DESCRIPTION
Added a conditional check to prevent non-contributors from entering the Patron Lounge from the Makerna Training Yard

Solves #3 